### PR TITLE
Add passes option to repeat full disk tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Run the tool with the following customizable options:
 - `--start-sector <sector>`: Starting sector for testing. Default: `0`.
 - `--end-sector <sector>`: Ending sector for testing. If omitted, tests until free space is exhausted.
 - `--random`: Use random data patterns instead of sequential patterns.
+- `--passes <number>`: Run the full disk test multiple times. Maximum of 3 passes.
 
 ### Example Commands
 1. Basic Test:


### PR DESCRIPTION
## Summary
- support running multiple passes of the FullTest command
- document the new `--passes` option
- clean up log reporting so each pass prints a pass summary and a single full summary is shown at the end

## Testing
- `cargo build --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68531cc432888331b4462aaace3b31f2