### PR TITLE
Use IOCTL to map drive letters to physical drives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ winapi = { version = "0.3.9", features = [
     "winnt",        # For HANDLE, ULARGE_INTEGER (definition), also where FileAllocationInfo enum member is defined for FILE_INFO_BY_HANDLE_CLASS
     "ioapiset",     # For DeviceIoControl
     "winerror",     # For ERROR_INSUFFICIENT_BUFFER constant
+    "handleapi",    # For CloseHandle
+    "winioctl",     # For IOCTL_STORAGE_GET_DEVICE_NUMBER
 ]}
 
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
## Summary
- add winioctl & handleapi features for Windows
- convert drive letters to physical device paths via IOCTL_STORAGE_GET_DEVICE_NUMBER
- query disk serial numbers from the resulting physical drive handle

## Testing
- `cargo test` *(fails: libudev not found)*
- `cargo check` *(fails: libudev not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b0de1ed08331bb2636ad54d0c35f