### PR TITLE
Show runtime version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2016,6 +2016,11 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
     setup_signal_handler();
     let cli = Cli::parse();
     log_simple(&log_file_arc_opt, None, "Starting Disk Test Tool...");
+    log_simple(
+        &log_file_arc_opt,
+        None,
+        format!("Running Version {}", env!("CARGO_PKG_VERSION")),
+    );
 
     if cli.verbose {
         log_simple(&log_file_arc_opt, None, format!("CLI Command: {:?}", cli));


### PR DESCRIPTION
## Summary
- make version available at runtime using `env!("CARGO_PKG_VERSION")`

## Testing
- `cargo test` *(fails: The system library `libudev` required by crate `libudev-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d35f7ca08331997eb5091948741a