### PR TITLE
Add macOS disk resolver and USB tree reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +223,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "disk_tester"
 version = "0.2.3"
 dependencies = [
@@ -233,8 +248,10 @@ dependencies = [
  "mach2",
  "num_cpus",
  "parking_lot",
+ "plist",
  "rand",
  "rusb",
+ "serde_json",
  "sysinfo",
  "tempfile",
  "thiserror",
@@ -247,6 +264,12 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -288,6 +311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +349,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
 ]
 
 [[package]]
@@ -361,6 +400,12 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -459,6 +504,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,10 +589,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plist"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d77244ce2d584cd84f6a15f86195b8c9b2a0dfbfd817c09e0464244091a58ed"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -559,6 +629,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -639,10 +718,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "shlex"
@@ -718,6 +835,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ rusb = "0.9"
 rand = "0.8"
 cfg-if = "1.0"
 thiserror = "2"
+plist = "1.7"
+serde_json = "1.0"
 winapi = { version = "0.3.9", features = [
     "fileapi",
     "handleapi",

--- a/src/mac_usb_report.rs
+++ b/src/mac_usb_report.rs
@@ -1,0 +1,144 @@
+#[cfg(target_os = "macos")]
+use std::io::{self, ErrorKind};
+#[cfg(target_os = "macos")]
+use std::process::Command;
+
+#[cfg(target_os = "macos")]
+use plist::Value;
+#[cfg(target_os = "macos")]
+use serde_json::{Map, Value as JsonValue};
+
+#[cfg(target_os = "macos")]
+pub fn usb_storage_report(path: &str) -> io::Result<String> {
+    let bsd = get_bsd_name_from_path(path).ok_or_else(|| {
+        io::Error::new(ErrorKind::NotFound, "Could not resolve BSD name for path")
+    })?;
+
+    let output = Command::new("system_profiler")
+        .args(["SPUSBDataType", "-json", "-detailLevel", "mini"])
+        .output()?;
+
+    let json: JsonValue = serde_json::from_slice(&output.stdout)
+        .map_err(|e| io::Error::new(ErrorKind::Other, e))?;
+    let items = json
+        .get("SPUSBDataType")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| io::Error::new(ErrorKind::Other, "Unexpected system_profiler output"))?;
+
+    let mut stack = Vec::new();
+    let path_nodes = search(items, &bsd, &mut stack)
+        .ok_or_else(|| io::Error::new(ErrorKind::NotFound, "USB path not found"))?;
+
+    let mut out = String::new();
+    for (depth, node) in path_nodes.iter().enumerate() {
+        if let Some(map) = node.as_object() {
+            pretty_usb_node(map, depth * 2, &mut out);
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(target_os = "macos")]
+fn search<'a>(value: &'a JsonValue, bsd: &str, stack: &mut Vec<&'a JsonValue>) -> Option<Vec<&'a JsonValue>> {
+    match value {
+        JsonValue::Object(map) => {
+            stack.push(value);
+            if map
+                .get("bsd_name")
+                .and_then(|v| v.as_str())
+                .map_or(false, |s| s.eq_ignore_ascii_case(bsd))
+                || map
+                    .get("BSD Name")
+                    .and_then(|v| v.as_str())
+                    .map_or(false, |s| s.eq_ignore_ascii_case(bsd))
+            {
+                return Some(stack.clone());
+            }
+            if let Some(res) = map.get("volumes").and_then(|v| search(v, bsd, stack)) {
+                return Some(res);
+            }
+            for val in map.values() {
+                if let Some(res) = search(val, bsd, stack) {
+                    return Some(res);
+                }
+            }
+            stack.pop();
+        }
+        JsonValue::Array(arr) => {
+            for val in arr {
+                if let Some(res) = search(val, bsd, stack) {
+                    return Some(res);
+                }
+            }
+        }
+        _ => {}
+    }
+    None
+}
+
+#[cfg(target_os = "macos")]
+fn pretty_usb_node(node: &Map<String, JsonValue>, indent: usize, out: &mut String) {
+    let ind = " ".repeat(indent);
+    if let Some(name) = node.get("_name").and_then(|v| v.as_str()) {
+        out.push_str(&format!("{ind}{name}\n"));
+    }
+
+    const KEYS: &[&str] = &[
+        "vendor_id",
+        "product_id",
+        "serial_num",
+        "speed",
+        "manufacturer",
+        "location_id",
+        "current_available",
+        "current_required",
+        "extra_current",
+        "pci_device_id",
+        "pci_revision_id",
+        "pci_vendor_id",
+    ];
+
+    for key in KEYS {
+        if let Some(v) = node.get(*key) {
+            if let Some(s) = v.as_str() {
+                out.push_str(&format!("{ind}  {key}: {s}\n"));
+            } else if let Some(n) = v.as_i64() {
+                out.push_str(&format!("{ind}  {key}: {n}\n"));
+            }
+        }
+    }
+
+    if let (Some(req), Some(avail)) = (
+        node.get("current_required").and_then(|v| v.as_u64()),
+        node.get("current_available").and_then(|v| v.as_u64()),
+    ) {
+        if req > avail && req != 0 {
+            out.push_str(&format!("{ind}  \u{26a0} draws {req} mA > {avail} mA supplied\n"));
+        }
+    }
+
+    if let Some(subs) = node.get("volumes").and_then(|v| v.as_array()) {
+        for sub in subs {
+            if let Some(map) = sub.as_object() {
+                pretty_usb_node(map, indent + 2, out);
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn get_bsd_name_from_path(path: &str) -> Option<String> {
+    let output = Command::new("diskutil")
+        .arg("info")
+        .arg("-plist")
+        .arg(path)
+        .output()
+        .ok()?;
+    let plist = Value::from_reader_xml(&*output.stdout).ok()?;
+    plist
+        .as_dictionary()
+        .and_then(|dict| dict.get("DeviceNode"))
+        .and_then(|node| node.as_string())
+        .map(|s| s.to_string())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,8 @@ use parking_lot::Mutex;
 use rand::{thread_rng, Rng};
 
 mod hardware_info;
+#[cfg(target_os = "macos")]
+mod mac_usb_report;
 mod serial;
 
 // Platform-specific imports
@@ -2241,6 +2243,19 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
             match hardware_info::get_usb_serial_numbers() {
                 Ok(serials) => log_simple(&log_file_arc_opt, None, serials),
                 Err(_) => log_simple(&log_file_arc_opt, None, "No USB disk serial numbers found."),
+            }
+            if let Ok(tree) = mac_usb_report::usb_storage_report(path_str) {
+                log_simple(
+                    &log_file_arc_opt,
+                    None,
+                    format!("USB / Controller Tree (incl. power) \u{2193}\n{tree}"),
+                );
+            } else {
+                log_simple(
+                    &log_file_arc_opt,
+                    None,
+                    "USB / Controller Tree: not found or error.",
+                );
             }
         }
         #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary
- improve disk resolution on macOS using `diskutil` plist output
- add `plist` and `serde_json` crates for macOS helpers
- implement a macOS USB controller tree reporter with power checks

## Testing
- `cargo check` *(fails: libudev pc file missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856650b5b2c8331a538baee1a6cdd09