### PR TITLE
Implement macOS SMART via IOKit, unify helpers

### DIFF
--- a/src/hardware_info.rs
+++ b/src/hardware_info.rs
@@ -10,6 +10,25 @@ use sysinfo::Disks;
 
 use rusb::{Context, DeviceHandle, UsbContext};
 
+#[cfg(target_os = "macos")]
+mod macos_iokit_stats;
+#[cfg(target_os = "macos")]
+pub use macos_iokit_stats::smart_metrics_from_bsd as smart_metrics;
+
+/// Basic SMART/health metrics gathered from the platform.
+#[derive(Debug, Default)]
+pub struct SmartMetrics {
+    pub power_on_hours: Option<u64>,
+    pub power_cycle_count: Option<u64>,
+    pub unexpected_power_loss: Option<u64>,
+    pub media_errors: Option<u64>,
+    pub data_units_written: Option<u64>,
+    pub data_units_read: Option<u64>,
+    pub percentage_used: Option<u8>,
+    pub temperature_c: Option<f64>,
+    pub smart_overall_health: Option<String>,
+}
+
 /// Retrieves information about the disk at the given path.
 #[cfg(not(target_os = "macos"))]
 pub fn get_disk_info(disk_path: &str) -> io::Result<String> {
@@ -48,7 +67,7 @@ pub fn get_disk_info(disk_path: &str) -> io::Result<String> {
 }
 
 #[cfg(target_os = "macos")]
-fn get_bsd_name_from_path(path: &str) -> Option<String> {
+pub fn get_bsd_name_from_path(path: &str) -> Option<String> {
     let output = Command::new("diskutil")
         .arg("info")
         .arg("-plist")

--- a/src/mac_usb_report.rs
+++ b/src/mac_usb_report.rs
@@ -7,6 +7,8 @@ use std::io::{self, ErrorKind};
 use std::process::Command;
 
 #[cfg(target_os = "macos")]
+use crate::hardware_info::get_bsd_name_from_path;
+#[cfg(target_os = "macos")]
 use plist::Value;
 #[cfg(target_os = "macos")]
 use serde_json::{Map, Value as JsonValue};
@@ -200,20 +202,4 @@ fn pretty_usb_node(node: &Map<String, JsonValue>, indent: usize, out: &mut Strin
             }
         }
     }
-}
-
-#[cfg(target_os = "macos")]
-fn get_bsd_name_from_path(path: &str) -> Option<String> {
-    let output = Command::new("diskutil")
-        .arg("info")
-        .arg("-plist")
-        .arg(path)
-        .output()
-        .ok()?;
-    let plist = Value::from_reader_xml(&*output.stdout).ok()?;
-    plist
-        .as_dictionary()
-        .and_then(|dict| dict.get("DeviceNode"))
-        .and_then(|node| node.as_string())
-        .map(|s| s.to_string())
 }

--- a/src/macos_iokit_stats.rs
+++ b/src/macos_iokit_stats.rs
@@ -1,0 +1,110 @@
+//! Minimal, dependency-free SMART reader for macOS 11-14.
+//! Works for internal NVMe and SATA/USB-SATA drives that expose SMART.
+
+#![cfg(target_os = "macos")]
+
+use core_foundation_sys::base::kCFAllocatorDefault;
+use io_kit_sys::{
+    io_iterator_t, io_object_t, io_service_t, IOIteratorNext, IORegistryEntryCreateCFProperties,
+    IOServiceGetMatchingServices, IOServiceMatching, KERN_SUCCESS,
+};
+use plist::{Dictionary, Value};
+use std::{ffi::CString, io, ptr};
+
+use crate::hardware_info::SmartMetrics; // <-- your shared struct
+
+/// Public entry-point used by main.rs
+pub fn smart_metrics_from_bsd(bsd_name: &str) -> io::Result<SmartMetrics> {
+    // 1) Try NVMe first (Apple NVMe controller & 3rd-party cards)
+    if let Ok(m) = pull_smart_dict("IONVMeSMARTUserClient", bsd_name).and_then(parse_nvme) {
+        return Ok(m);
+    }
+    // 2) Fallback: SATA / USB-SATA
+    if let Ok(m) = pull_smart_dict("IOSATSMARTUserClient", bsd_name).and_then(parse_sata) {
+        return Ok(m);
+    }
+
+    Err(io::Error::new(
+        io::ErrorKind::Other,
+        "SMART user-client not found",
+    ))
+}
+
+/// Low-level helper: find the first user-client of `class_name` whose parent
+/// block-storage object has the given BSD name.  Returns its property dict.
+fn pull_smart_dict(class_name: &str, bsd: &str) -> io::Result<Dictionary> {
+    unsafe {
+        let matching = IOServiceMatching(CString::new(class_name)?.as_ptr());
+        if matching.is_null() {
+            return Err(ioerr("failed to create matching dict"));
+        }
+        let mut it: io_iterator_t = 0;
+        if IOServiceGetMatchingServices(0, matching, &mut it) != KERN_SUCCESS {
+            return Err(ioerr("no services"));
+        }
+        let mut svc: io_service_t = IOIteratorNext(it);
+        while svc != 0 {
+            let mut cf_props = ptr::null_mut();
+            IORegistryEntryCreateCFProperties(svc, &mut cf_props, kCFAllocatorDefault, 0);
+            if cf_props.is_null() {
+                svc = IOIteratorNext(it);
+                continue;
+            }
+            let v = Value::from_cf_type_ref(cf_props);
+            // The SMART user-client itself doesn\'t contain the BSD name; walk one
+            // level up ("IOBlockStorageDevice") via the "Parent Root" key.
+            if let Some(Value::Dictionary(dict)) = v.lookup("Parent Root") {
+                if dict
+                    .lookup("BSD Name")
+                    .and_then(Value::as_string)
+                    .map(|s| s.eq_ignore_ascii_case(bsd))
+                    .unwrap_or(false)
+                {
+                    return v
+                        .lookup("SMART Data")
+                        .and_then(Value::as_dictionary)
+                        .cloned()
+                        .ok_or_else(|| ioerr("SMART Data key missing"));
+                }
+            }
+            svc = IOIteratorNext(it);
+        }
+        Err(ioerr("service not found"))
+    }
+}
+
+fn parse_nvme(d: Dictionary) -> io::Result<SmartMetrics> {
+    let mut m = SmartMetrics::default();
+    m.power_on_hours = d.lookup("PowerOnHours").and_then(Value::as_u64);
+    m.unexpected_power_loss = d.lookup("UnsafeShutdowns").and_then(Value::as_u64);
+    m.media_errors = d.lookup("MediaErrors").and_then(Value::as_u64);
+    m.data_units_written = d.lookup("DataUnitsWritten").and_then(Value::as_u64);
+    m.data_units_read = d.lookup("DataUnitsRead").and_then(Value::as_u64);
+    m.percentage_used = d
+        .lookup("PercentageUsed")
+        .and_then(Value::as_u64)
+        .map(|v| v as u8);
+    m.temperature_c = d.lookup("Temperature").and_then(Value::as_f64);
+    m.smart_overall_health = d
+        .lookup("OverallHealth")
+        .and_then(Value::as_string)
+        .map(|s| s.to_string());
+    Ok(m)
+}
+
+fn parse_sata(d: Dictionary) -> io::Result<SmartMetrics> {
+    let mut m = SmartMetrics::default();
+    m.smart_overall_health = d
+        .lookup("OverallHealth")
+        .and_then(Value::as_string)
+        .map(|s| s.to_string());
+    m.power_on_hours = d.lookup("PowerOnHours").and_then(Value::as_u64);
+    m.power_cycle_count = d.lookup("PowerCycles").and_then(Value::as_u64);
+    m.media_errors = d.lookup("MediaErrors").and_then(Value::as_u64);
+    m.temperature_c = d.lookup("Temperature").and_then(Value::as_f64);
+    Ok(m)
+}
+
+fn ioerr(msg: &str) -> io::Error {
+    io::Error::new(io::ErrorKind::Other, msg)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2250,6 +2250,11 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
                     format!("Block Size: {} bytes", bsize),
                 );
             }
+            if let Some(bsd) = hardware_info::get_bsd_name_from_path(path_str) {
+                if let Ok(smart) = hardware_info::smart_metrics(&bsd) {
+                    log_simple(&log_file_arc_opt, None, format!("SMART {:?}", smart));
+                }
+            }
             match mac_usb_report::usb_storage_summary(path_str) {
                 Ok(s) => log_simple(&log_file_arc_opt, None, s),
                 Err(_) => log_simple(


### PR DESCRIPTION
## Summary
- add IOKit based SMART metrics reader for macOS
- expose `get_bsd_name_from_path` for reuse and remove duplicate
- log SMART metrics in main when running on macOS
- tidy imports and structs

## Testing
- `cargo fmt`
- `cargo test --quiet` *(fails: libudev.pc missing)*

------
https://chatgpt.com/codex/tasks/task_e_68577644a51c833187515db85fcc94db