### PR TITLE
Add drive descriptor and controller tree scaffolding

### DIFF
--- a/src/controller_tree.rs
+++ b/src/controller_tree.rs
@@ -30,8 +30,8 @@ pub fn controller_tree_for_path(p: &str) -> std::io::Result<Vec<ControllerNode>>
 #[cfg(target_os = "linux")]
 fn linux_tree(p: &str) -> std::io::Result<Vec<ControllerNode>> {
     use std::{fs, io, path::Path};
-
-    let dev = fs::canonicalize(p)?;
+    let path = crate::path_utils::canonical_block(p)?;
+    let dev = fs::canonicalize(&path)?;
     let name = dev
         .file_name()
         .and_then(|s| s.to_str())
@@ -83,11 +83,13 @@ fn linux_tree(p: &str) -> std::io::Result<Vec<ControllerNode>> {
 }
 
 #[cfg(target_os = "macos")]
-fn mac_tree(_p: &str) -> std::io::Result<Vec<ControllerNode>> {
+fn mac_tree(p: &str) -> std::io::Result<Vec<ControllerNode>> {
+    let _ = crate::path_utils::canonical_block(p)?;
     Ok(Vec::new())
 }
 
 #[cfg(target_os = "windows")]
-fn win_tree(_p: &str) -> std::io::Result<Vec<ControllerNode>> {
+fn win_tree(p: &str) -> std::io::Result<Vec<ControllerNode>> {
+    let _ = crate::path_utils::canonical_block(p)?;
     Ok(Vec::new())
 }

--- a/src/controller_tree.rs
+++ b/src/controller_tree.rs
@@ -71,7 +71,7 @@ fn linux_tree(p: &str) -> std::io::Result<Vec<ControllerNode>> {
             pid,
         });
 
-        if path == Path::new("/sys/devices") {
+        if path.starts_with("/sys/devices") && path.parent().is_none() {
             break;
         }
         if !path.pop() {

--- a/src/controller_tree.rs
+++ b/src/controller_tree.rs
@@ -1,0 +1,93 @@
+use crate::drive_descriptor::BusType;
+
+#[derive(Debug)]
+pub struct ControllerNode {
+    pub label: String,
+    pub bus: BusType,
+    pub vid: Option<u16>,
+    pub pid: Option<u16>,
+}
+
+pub fn controller_tree_for_path(p: &str) -> std::io::Result<Vec<ControllerNode>> {
+    #[cfg(target_os = "linux")]
+    {
+        return linux_tree(p);
+    }
+    #[cfg(target_os = "macos")]
+    {
+        return mac_tree(p);
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return win_tree(p);
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        "OS-unsupported",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn linux_tree(p: &str) -> std::io::Result<Vec<ControllerNode>> {
+    use std::{fs, io, path::Path};
+
+    let dev = fs::canonicalize(p)?;
+    let name = dev
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "invalid device"))?;
+    let mut path = fs::canonicalize(Path::new("/sys/block").join(name).join("device"))?;
+    let mut nodes_rev = Vec::new();
+    loop {
+        let label = path
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+        let bus = fs::read_link(path.join("subsystem"))
+            .ok()
+            .and_then(|l| {
+                l.file_name().and_then(|s| s.to_str()).map(|s| match s {
+                    "nvme" => BusType::Nvme,
+                    "usb" => BusType::Usb,
+                    "mmc" => BusType::Sd,
+                    "sas" => BusType::Sas,
+                    "scsi" => BusType::Sata,
+                    _ => BusType::Unknown,
+                })
+            })
+            .unwrap_or(BusType::Unknown);
+
+        let vid = fs::read_to_string(path.join("idVendor"))
+            .ok()
+            .and_then(|s| u16::from_str_radix(s.trim(), 16).ok());
+        let pid = fs::read_to_string(path.join("idProduct"))
+            .ok()
+            .and_then(|s| u16::from_str_radix(s.trim(), 16).ok());
+        nodes_rev.push(ControllerNode {
+            label,
+            bus,
+            vid,
+            pid,
+        });
+
+        if path == Path::new("/sys/devices") {
+            break;
+        }
+        if !path.pop() {
+            break;
+        }
+    }
+    nodes_rev.reverse();
+    Ok(nodes_rev)
+}
+
+#[cfg(target_os = "macos")]
+fn mac_tree(_p: &str) -> std::io::Result<Vec<ControllerNode>> {
+    Ok(Vec::new())
+}
+
+#[cfg(target_os = "windows")]
+fn win_tree(_p: &str) -> std::io::Result<Vec<ControllerNode>> {
+    Ok(Vec::new())
+}

--- a/src/drive_descriptor.rs
+++ b/src/drive_descriptor.rs
@@ -139,12 +139,12 @@ fn mac_descriptor(p: &str) -> std::io::Result<DriveDescriptor> {
 
     let rotational = dict
         .get("SolidState")
-        .and_then(|v| v.as_bool())
+        .and_then(|v| v.as_boolean())
         .map(|solid| !solid);
 
     let sector_size = dict
         .get("DeviceBlockSize")
-        .and_then(|v| v.as_integer())
+        .and_then(|v| v.as_signed_integer())
         .map(|n| n as u32);
 
     let media = if rotational == Some(true) {

--- a/src/drive_descriptor.rs
+++ b/src/drive_descriptor.rs
@@ -1,0 +1,230 @@
+#[derive(Debug, Clone, Copy)]
+pub enum BusType {
+    Usb,
+    Nvme,
+    Sata,
+    Sas,
+    Sd,
+    Thunderbolt,
+    Unknown,
+}
+
+impl Default for BusType {
+    fn default() -> Self {
+        BusType::Unknown
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum MediaKind {
+    Ssd,
+    Hdd,
+    Optical,
+    FlashRemovable,
+    Unknown,
+}
+
+impl Default for MediaKind {
+    fn default() -> Self {
+        MediaKind::Unknown
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct DriveDescriptor {
+    pub bus: BusType,
+    pub media: MediaKind,
+    pub rotational: Option<bool>,
+    pub sector_size: Option<u32>,
+}
+
+pub fn drive_descriptor_from_path(p: &str) -> std::io::Result<DriveDescriptor> {
+    #[cfg(target_os = "linux")]
+    {
+        return linux_descriptor(p);
+    }
+    #[cfg(target_os = "macos")]
+    {
+        return mac_descriptor(p);
+    }
+    #[cfg(target_os = "windows")]
+    {
+        return win_descriptor(p);
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        "OS-unsupported",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+fn linux_descriptor(p: &str) -> std::io::Result<DriveDescriptor> {
+    use std::{fs, io, path::Path};
+
+    let dev = fs::canonicalize(p)?;
+    let name = dev
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "invalid device"))?;
+
+    let sys_path = Path::new("/sys/block").join(name);
+
+    let rotational = fs::read_to_string(sys_path.join("queue/rotational"))
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok())
+        .map(|v| v != 0);
+
+    let sector_size = fs::read_to_string(sys_path.join("queue/logical_block_size"))
+        .ok()
+        .and_then(|v| v.trim().parse::<u32>().ok());
+
+    let bus = fs::read_link(sys_path.join("device/subsystem"))
+        .ok()
+        .and_then(|l| {
+            l.file_name().and_then(|s| s.to_str()).map(|s| match s {
+                "nvme" => BusType::Nvme,
+                "usb" => BusType::Usb,
+                "mmc" => BusType::Sd,
+                "sas" => BusType::Sas,
+                "scsi" => BusType::Sata,
+                _ => BusType::Unknown,
+            })
+        })
+        .unwrap_or(BusType::Unknown);
+
+    let media = if rotational == Some(true) {
+        MediaKind::Hdd
+    } else {
+        MediaKind::Ssd
+    };
+
+    Ok(DriveDescriptor {
+        bus,
+        media,
+        rotational,
+        sector_size,
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn mac_descriptor(p: &str) -> std::io::Result<DriveDescriptor> {
+    use plist::Value;
+    use std::{io, process::Command};
+
+    let out = Command::new("diskutil")
+        .arg("info")
+        .arg("-plist")
+        .arg(p)
+        .output()?;
+
+    let plist = Value::from_reader_xml(&*out.stdout)
+        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+    let dict = plist
+        .as_dictionary()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "unexpected output"))?;
+
+    let bus = dict
+        .get("BusProtocol")
+        .and_then(|v| v.as_string())
+        .map(|s| match s.to_ascii_lowercase().as_str() {
+            "usb" => BusType::Usb,
+            "nvme" | "pci-express" => BusType::Nvme,
+            "sata" => BusType::Sata,
+            "sas" => BusType::Sas,
+            "sd" | "mmc" => BusType::Sd,
+            "thunderbolt" => BusType::Thunderbolt,
+            _ => BusType::Unknown,
+        })
+        .unwrap_or(BusType::Unknown);
+
+    let rotational = dict
+        .get("SolidState")
+        .and_then(|v| v.as_bool())
+        .map(|solid| !solid);
+
+    let sector_size = dict
+        .get("DeviceBlockSize")
+        .and_then(|v| v.as_integer())
+        .map(|n| n as u32);
+
+    let media = if rotational == Some(true) {
+        MediaKind::Hdd
+    } else {
+        MediaKind::Ssd
+    };
+
+    Ok(DriveDescriptor {
+        bus,
+        media,
+        rotational,
+        sector_size,
+    })
+}
+
+#[cfg(target_os = "windows")]
+fn win_descriptor(p: &str) -> std::io::Result<DriveDescriptor> {
+    use std::{io, mem, os::windows::prelude::*, ptr};
+    use winapi::um::{
+        fileapi::CreateFileW,
+        handleapi::CloseHandle,
+        ioapiset::DeviceIoControl,
+        winbase::FILE_FLAG_BACKUP_SEMANTICS,
+        winioctl::{DISK_GEOMETRY, IOCTL_DISK_GET_DRIVE_GEOMETRY},
+        winnt::{FILE_SHARE_READ, FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE},
+    };
+
+    let mut wide: Vec<u16> = std::ffi::OsStr::new(p).encode_wide().collect();
+    if !p.ends_with('\0') {
+        wide.push(0);
+    }
+
+    unsafe {
+        let handle = CreateFileW(
+            wide.as_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            ptr::null_mut(),
+            3, // OPEN_EXISTING
+            FILE_FLAG_BACKUP_SEMANTICS,
+            ptr::null_mut(),
+        );
+        if handle.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+
+        let mut geom: DISK_GEOMETRY = mem::zeroed();
+        let mut bytes = 0u32;
+        let ok = DeviceIoControl(
+            handle,
+            IOCTL_DISK_GET_DRIVE_GEOMETRY,
+            ptr::null_mut(),
+            0,
+            &mut geom as *mut _ as *mut _,
+            mem::size_of::<DISK_GEOMETRY>() as u32,
+            &mut bytes,
+            ptr::null_mut(),
+        );
+        CloseHandle(handle);
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let rotational = match geom.MediaType {
+            12 | 13 => Some(false), // FixedMedia or SSD
+            _ => Some(true),
+        };
+
+        let sector_size = Some(geom.BytesPerSector as u32);
+
+        Ok(DriveDescriptor {
+            bus: BusType::Unknown,
+            media: if rotational == Some(true) {
+                MediaKind::Hdd
+            } else {
+                MediaKind::Ssd
+            },
+            rotational,
+            sector_size,
+        })
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,6 +361,19 @@ fn log_simple<S: AsRef<str>>(
     log_message_internal(log_f, pb, msg_with_ts);
 }
 
+fn log_drive_info<P: AsRef<Path>>(log_f: &Option<Arc<Mutex<File>>>, p: P) {
+    if let Some(s) = p.as_ref().as_os_str().to_str() {
+        if let Ok(dd) = drive_descriptor::drive_descriptor_from_path(s) {
+            log_simple(log_f, None, format!("Drive: {:?}", dd));
+        }
+        if let Ok(tree) = controller_tree::controller_tree_for_path(s) {
+            for n in tree {
+                log_simple(log_f, None, format!("  └─ {}", n.label));
+            }
+        }
+    }
+}
+
 fn log_error(
     log_f: &Option<Arc<Mutex<File>>>,
     pb: Option<&Arc<ProgressBar>>,
@@ -2315,16 +2328,7 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
             let use_direct_io = false;
 
             let file_path = resolve_file_path(path, &log_file_arc_opt)?;
-            if let Some(pstr) = file_path.to_str() {
-                if let Ok(dd) = drive_descriptor::drive_descriptor_from_path(pstr) {
-                    log_simple(&log_file_arc_opt, None, format!("Drive: {:?}", dd));
-                }
-                if let Ok(tree) = controller_tree::controller_tree_for_path(pstr) {
-                    for n in tree {
-                        log_simple(&log_file_arc_opt, None, format!("  └─ {}", n.label));
-                    }
-                }
-            }
+            log_drive_info(&log_file_arc_opt, &file_path);
             let mut actual_block_size_u64 = block_size;
             if actual_block_size_u64 == 0 {
                 log_simple(
@@ -2513,16 +2517,7 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
             let use_direct_io = false;
 
             let file_path = resolve_file_path(Some(path), &log_file_arc_opt)?;
-            if let Some(pstr) = file_path.to_str() {
-                if let Ok(dd) = drive_descriptor::drive_descriptor_from_path(pstr) {
-                    log_simple(&log_file_arc_opt, None, format!("Drive: {:?}", dd));
-                }
-                if let Ok(tree) = controller_tree::controller_tree_for_path(pstr) {
-                    for n in tree {
-                        log_simple(&log_file_arc_opt, None, format!("  └─ {}", n.label));
-                    }
-                }
-            }
+            log_drive_info(&log_file_arc_opt, &file_path);
             let mut actual_block_size_u64 = block_size;
             if actual_block_size_u64 == 0 {
                 log_simple(
@@ -2564,16 +2559,7 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
             let use_direct_io = false;
 
             let file_path = resolve_file_path(Some(path), &log_file_arc_opt)?;
-            if let Some(pstr) = file_path.to_str() {
-                if let Ok(dd) = drive_descriptor::drive_descriptor_from_path(pstr) {
-                    log_simple(&log_file_arc_opt, None, format!("Drive: {:?}", dd));
-                }
-                if let Ok(tree) = controller_tree::controller_tree_for_path(pstr) {
-                    for n in tree {
-                        log_simple(&log_file_arc_opt, None, format!("  └─ {}", n.label));
-                    }
-                }
-            }
+            log_drive_info(&log_file_arc_opt, &file_path);
             let mut actual_block_size_u64 = block_size;
             if actual_block_size_u64 == 0 {
                 log_simple(
@@ -2638,16 +2624,7 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
             let use_direct_io = false;
 
             let file_path = resolve_file_path(Some(path), &log_file_arc_opt)?;
-            if let Some(pstr) = file_path.to_str() {
-                if let Ok(dd) = drive_descriptor::drive_descriptor_from_path(pstr) {
-                    log_simple(&log_file_arc_opt, None, format!("Drive: {:?}", dd));
-                }
-                if let Ok(tree) = controller_tree::controller_tree_for_path(pstr) {
-                    for n in tree {
-                        log_simple(&log_file_arc_opt, None, format!("  └─ {}", n.label));
-                    }
-                }
-            }
+            log_drive_info(&log_file_arc_opt, &file_path);
             let mut actual_block_size_u64 = block_size;
             if actual_block_size_u64 == 0 {
                 log_simple(
@@ -2692,16 +2669,7 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
             let use_direct_io = false;
 
             let file_path = resolve_file_path(Some(path), &log_file_arc_opt)?;
-            if let Some(pstr) = file_path.to_str() {
-                if let Ok(dd) = drive_descriptor::drive_descriptor_from_path(pstr) {
-                    log_simple(&log_file_arc_opt, None, format!("Drive: {:?}", dd));
-                }
-                if let Ok(tree) = controller_tree::controller_tree_for_path(pstr) {
-                    for n in tree {
-                        log_simple(&log_file_arc_opt, None, format!("  └─ {}", n.label));
-                    }
-                }
-            }
+            log_drive_info(&log_file_arc_opt, &file_path);
             let mut actual_block_size_u64 = block_size;
             if actual_block_size_u64 == 0 {
                 log_simple(
@@ -2769,16 +2737,7 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
             let use_direct_io = false;
 
             let file_path = resolve_file_path(Some(path), &log_file_arc_opt)?;
-            if let Some(pstr) = file_path.to_str() {
-                if let Ok(dd) = drive_descriptor::drive_descriptor_from_path(pstr) {
-                    log_simple(&log_file_arc_opt, None, format!("Drive: {:?}", dd));
-                }
-                if let Ok(tree) = controller_tree::controller_tree_for_path(pstr) {
-                    for n in tree {
-                        log_simple(&log_file_arc_opt, None, format!("  └─ {}", n.label));
-                    }
-                }
-            }
+            log_drive_info(&log_file_arc_opt, &file_path);
             let mut actual_block_size_u64 = block_size;
             if actual_block_size_u64 == 0 {
                 log_simple(

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,8 @@ use indicatif::{ProgressBar, ProgressStyle};
 use parking_lot::Mutex;
 use rand::{thread_rng, Rng};
 
+mod controller_tree;
+mod drive_descriptor;
 mod hardware_info;
 #[cfg(target_os = "macos")]
 mod mac_usb_report;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use rand::{thread_rng, Rng};
 mod controller_tree;
 mod drive_descriptor;
 mod hardware_info;
+mod path_utils;
 #[cfg(target_os = "macos")]
 mod mac_usb_report;
 #[cfg(all(target_os = "macos", feature = "direct"))]
@@ -2314,6 +2315,16 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
             let use_direct_io = false;
 
             let file_path = resolve_file_path(path, &log_file_arc_opt)?;
+            if let Some(pstr) = file_path.to_str() {
+                if let Ok(dd) = drive_descriptor::drive_descriptor_from_path(pstr) {
+                    log_simple(&log_file_arc_opt, None, format!("Drive: {:?}", dd));
+                }
+                if let Ok(tree) = controller_tree::controller_tree_for_path(pstr) {
+                    for n in tree {
+                        log_simple(&log_file_arc_opt, None, format!("  └─ {}", n.label));
+                    }
+                }
+            }
             let mut actual_block_size_u64 = block_size;
             if actual_block_size_u64 == 0 {
                 log_simple(
@@ -2502,6 +2513,16 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
             let use_direct_io = false;
 
             let file_path = resolve_file_path(Some(path), &log_file_arc_opt)?;
+            if let Some(pstr) = file_path.to_str() {
+                if let Ok(dd) = drive_descriptor::drive_descriptor_from_path(pstr) {
+                    log_simple(&log_file_arc_opt, None, format!("Drive: {:?}", dd));
+                }
+                if let Ok(tree) = controller_tree::controller_tree_for_path(pstr) {
+                    for n in tree {
+                        log_simple(&log_file_arc_opt, None, format!("  └─ {}", n.label));
+                    }
+                }
+            }
             let mut actual_block_size_u64 = block_size;
             if actual_block_size_u64 == 0 {
                 log_simple(
@@ -2543,6 +2564,16 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
             let use_direct_io = false;
 
             let file_path = resolve_file_path(Some(path), &log_file_arc_opt)?;
+            if let Some(pstr) = file_path.to_str() {
+                if let Ok(dd) = drive_descriptor::drive_descriptor_from_path(pstr) {
+                    log_simple(&log_file_arc_opt, None, format!("Drive: {:?}", dd));
+                }
+                if let Ok(tree) = controller_tree::controller_tree_for_path(pstr) {
+                    for n in tree {
+                        log_simple(&log_file_arc_opt, None, format!("  └─ {}", n.label));
+                    }
+                }
+            }
             let mut actual_block_size_u64 = block_size;
             if actual_block_size_u64 == 0 {
                 log_simple(
@@ -2607,6 +2638,16 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
             let use_direct_io = false;
 
             let file_path = resolve_file_path(Some(path), &log_file_arc_opt)?;
+            if let Some(pstr) = file_path.to_str() {
+                if let Ok(dd) = drive_descriptor::drive_descriptor_from_path(pstr) {
+                    log_simple(&log_file_arc_opt, None, format!("Drive: {:?}", dd));
+                }
+                if let Ok(tree) = controller_tree::controller_tree_for_path(pstr) {
+                    for n in tree {
+                        log_simple(&log_file_arc_opt, None, format!("  └─ {}", n.label));
+                    }
+                }
+            }
             let mut actual_block_size_u64 = block_size;
             if actual_block_size_u64 == 0 {
                 log_simple(
@@ -2651,6 +2692,16 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
             let use_direct_io = false;
 
             let file_path = resolve_file_path(Some(path), &log_file_arc_opt)?;
+            if let Some(pstr) = file_path.to_str() {
+                if let Ok(dd) = drive_descriptor::drive_descriptor_from_path(pstr) {
+                    log_simple(&log_file_arc_opt, None, format!("Drive: {:?}", dd));
+                }
+                if let Ok(tree) = controller_tree::controller_tree_for_path(pstr) {
+                    for n in tree {
+                        log_simple(&log_file_arc_opt, None, format!("  └─ {}", n.label));
+                    }
+                }
+            }
             let mut actual_block_size_u64 = block_size;
             if actual_block_size_u64 == 0 {
                 log_simple(
@@ -2718,6 +2769,16 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
             let use_direct_io = false;
 
             let file_path = resolve_file_path(Some(path), &log_file_arc_opt)?;
+            if let Some(pstr) = file_path.to_str() {
+                if let Ok(dd) = drive_descriptor::drive_descriptor_from_path(pstr) {
+                    log_simple(&log_file_arc_opt, None, format!("Drive: {:?}", dd));
+                }
+                if let Ok(tree) = controller_tree::controller_tree_for_path(pstr) {
+                    for n in tree {
+                        log_simple(&log_file_arc_opt, None, format!("  └─ {}", n.label));
+                    }
+                }
+            }
             let mut actual_block_size_u64 = block_size;
             if actual_block_size_u64 == 0 {
                 log_simple(

--- a/src/path_utils.rs
+++ b/src/path_utils.rs
@@ -1,0 +1,61 @@
+use std::{io, path::{Path, PathBuf}};
+
+/// Return the canonical block-device *node* (e.g. `/dev/nvme0n1`)
+/// for a mount-point or any regular file on that filesystem.
+/// Works transparently when the caller already passed a device path.
+pub fn canonical_block<P: AsRef<Path>>(p: P) -> io::Result<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        use plist::Value;
+        use std::process::Command;
+
+        let out = Command::new("diskutil")
+            .args(["info", "-plist", p.as_ref().to_str().unwrap()])
+            .output()?;
+        let dict = Value::from_reader_xml(&*out.stdout)
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
+            .into_dictionary()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "plist parse fail"))?;
+        let dev = dict
+            .get("DeviceNode")
+            .and_then(Value::as_string)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "no DeviceNode"))?;
+        return Ok(PathBuf::from(dev));
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        let md = std::fs::metadata(&p)?;
+        let dev = md.dev();
+        let major = unsafe { libc::major(dev) };
+        let minor = unsafe { libc::minor(dev) };
+        let sys = std::fs::read_link(format!("/sys/dev/block/{major}:{minor}"))?;
+        let name = sys
+            .file_name()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "bad sysfs link"))?;
+        return Ok(PathBuf::from("/dev").join(name));
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::path::Component;
+        let root = p
+            .as_ref()
+            .components()
+            .next()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "bad path"))?;
+        if let Component::Prefix(pref) = root {
+            if let std::path::Prefix::Disk(d) = pref.kind() {
+                return Ok(PathBuf::from(format!("\\\\.\\{}:", d as char)));
+            }
+        }
+        return Err(io::Error::new(io::ErrorKind::Other, "cannot resolve"));
+    }
+
+    #[allow(unreachable_code)]
+    {
+        Err(io::Error::new(io::ErrorKind::Other, "OS-unsupported"))
+    }
+}


### PR DESCRIPTION
## Summary
- add enums and struct for describing drives
- add OS-specific drive descriptor helpers
- add controller tree utility for Linux with macOS/Windows stubs
- register new modules in `main.rs`

## Testing
- `cargo check`
- `cargo test --no-run`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_685845b9b9f0833196e94030dd43f27c