### PR TITLE
Delete test file after each pass

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2488,7 +2488,52 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
                             .push_str(" A fatal error was also encountered during the test.");
                     }
                     log_simple(&log_file_arc_opt, None, &error_summary_msg);
+                    // Remove the test file even when errors are encountered
+                    match fs::remove_file(&file_path) {
+                        Ok(_) => log_simple(
+                            &log_file_arc_opt,
+                            None,
+                            format!(
+                                "Deleted test file '{}' after pass {}",
+                                file_path.display(),
+                                pass_idx + 1
+                            ),
+                        ),
+                        Err(e) => log_simple(
+                            &log_file_arc_opt,
+                            None,
+                            format!(
+                                "Failed to delete test file '{}' after pass {}: {}",
+                                file_path.display(),
+                                pass_idx + 1,
+                                e
+                            ),
+                        ),
+                    }
                     return Err(io::Error::new(ErrorKind::Other, error_summary_msg));
+                }
+
+                // Clean up the test file before the next iteration
+                match fs::remove_file(&file_path) {
+                    Ok(_) => log_simple(
+                        &log_file_arc_opt,
+                        None,
+                        format!(
+                            "Deleted test file '{}' after pass {}",
+                            file_path.display(),
+                            pass_idx + 1
+                        ),
+                    ),
+                    Err(e) => log_simple(
+                        &log_file_arc_opt,
+                        None,
+                        format!(
+                            "Failed to delete test file '{}' after pass {}: {}",
+                            file_path.display(),
+                            pass_idx + 1,
+                            e
+                        ),
+                    ),
                 }
             }
         }


### PR DESCRIPTION
## Summary
- clean up test file after each test pass to ensure a fresh run

## Testing
- `cargo check` *(fails: libudev not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68656d4255488331a17596a97b124094