### PR TITLE
Deterministic RNG for random pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ num_cpus = "1.16.0"
 crossbeam-channel = "0.5"
 sysinfo = "0.35"
 rusb = "0.9"
-rand = "0.8"
+rand = { version = "0.8", features = ["small_rng"] }
 cfg-if = "1.0"
 thiserror = "2"
 once_cell = "1.19"


### PR DESCRIPTION
## Summary
- seed the RNG per sector to keep the random pattern reproducible
- enable `small_rng` feature in `rand`
- remove now-unused `thread_rng` import
- assert deterministic random pattern behavior in tests
- choose random/even block generation based on LBA parity

## Testing
- `cargo test --features direct`

------
https://chatgpt.com/codex/tasks/task_e_68703c7bc08c8331a7f51b1202fb0565