### PR TITLE
Add bus detection and auto‑tune helpers

### DIFF
--- a/src/auto_tune.rs
+++ b/src/auto_tune.rs
@@ -4,7 +4,7 @@ use crate::hardware_info::{detect_bus_type, Bus};
 use std::cmp;
 
 /// Returns `(threads, queue_depth, batch_size_bytes)`.
-pub fn decide<P: AsRef<std::path::Path>>(
+pub fn decide<P: AsRef<std::path::Path> + AsRef<std::ffi::OsStr>>(
     path: P,
     user_threads: Option<usize>,
     user_qd: Option<usize>,

--- a/src/auto_tune.rs
+++ b/src/auto_tune.rs
@@ -1,0 +1,39 @@
+//! Decide sensible defaults when the user did **not** override them.
+
+use crate::hardware_info::{detect_bus_type, Bus};
+use std::cmp;
+
+/// Returns `(threads, queue_depth, batch_size_bytes)`.
+pub fn decide<P: AsRef<std::path::Path>>(
+    path: P,
+    user_threads: Option<usize>,
+    user_qd: Option<usize>,
+    user_batch: Option<u64>,
+    block_size: u64,
+) -> (usize, usize, u64) {
+    // First honour any explicit override -------------------------------
+    let threads = user_threads.unwrap_or(0);
+    let qd_in   = user_qd.unwrap_or(0);
+    let batch   = user_batch.unwrap_or(0);
+
+    if threads > 0 && qd_in > 0 && batch > 0 {
+        return (threads, qd_in, batch);
+    }
+
+    // Otherwise pick presets based on the bus --------------------------
+    let bus = detect_bus_type(path).unwrap_or(Bus::Unknown);
+    let (def_thr, def_qd, def_batch_mb) = match bus {
+        Bus::UsbBulkOnly => (1, 1,   64),   // keep BOT bridges happy
+        Bus::UsbUasp     => (1, 8,  128),
+        Bus::SataAHCI    => (1, 8,  256),
+        Bus::Nvme        => (1, 32, 512),
+        _                => (1, 4,  128),
+    };
+
+    let threads = if threads == 0 { def_thr } else { threads };
+    let qd      = if qd_in  == 0 { def_qd  } else { qd_in  };
+    let batch_b = if batch   == 0 { def_batch_mb * 1_048_576 } else { batch };
+
+    // Never let batch be < 2 x block-size so the progress meter isn't spammy
+    (threads, qd, cmp::max(batch_b, 2 * block_size))
+}

--- a/src/hardware_info/bus.rs
+++ b/src/hardware_info/bus.rs
@@ -18,6 +18,7 @@ pub enum Bus {
 
 #[cfg(target_os = "windows")]
 pub fn detect_bus_type<P: AsRef<std::ffi::OsStr>>(path: P) -> io::Result<Bus> {
+    use crate::serial::windows::STORAGE_DEVICE_DESCRIPTOR;
     use std::{mem, os::windows::prelude::*};
     use winapi::shared::minwindef::DWORD;
     use winapi::um::{
@@ -26,8 +27,8 @@ pub fn detect_bus_type<P: AsRef<std::ffi::OsStr>>(path: P) -> io::Result<Bus> {
         ioapiset::DeviceIoControl,
         winbase::FILE_FLAG_BACKUP_SEMANTICS,
         winioctl::{
-            IOCTL_STORAGE_QUERY_PROPERTY, STORAGE_DEVICE_DESCRIPTOR,
-            STORAGE_PROPERTY_QUERY, StorageDeviceProperty,
+            IOCTL_STORAGE_QUERY_PROPERTY, STORAGE_PROPERTY_QUERY,
+            StorageDeviceProperty,
         },
         winnt::{FILE_SHARE_READ, FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE, HANDLE},
     };
@@ -76,7 +77,7 @@ pub fn detect_bus_type<P: AsRef<std::ffi::OsStr>>(path: P) -> io::Result<Bus> {
 
     // The first byte of STORAGE_DEVICE_DESCRIPTOR after the header length
     // is *BusType* (see winioctl.h).
-    let header_len = unsafe { (*(buf.as_ptr() as *const STORAGE_DEVICE_DESCRIPTOR)).HeaderSize };
+    let header_len = unsafe { (*(buf.as_ptr() as *const STORAGE_DEVICE_DESCRIPTOR)).size };
     let bus_byte = buf[header_len as usize];
 
     let bus = match bus_byte {

--- a/src/hardware_info/bus.rs
+++ b/src/hardware_info/bus.rs
@@ -1,0 +1,130 @@
+//! Lightweight bus-type detector used by the auto-tuner.
+//!
+//! Windows  : STORAGE_QUERY_PROPERTY
+//! Linux    : /sys/dev/block/…
+//! macOS    : IORegistry (re-uses your existing helper)
+
+use std::io;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Bus {
+    UsbBulkOnly,
+    UsbUasp,
+    SataAHCI,
+    Nvme,
+    Sas,
+    Unknown,
+}
+
+#[cfg(target_os = "windows")]
+pub fn detect_bus_type<P: AsRef<std::ffi::OsStr>>(path: P) -> io::Result<Bus> {
+    use std::{mem, os::windows::prelude::*};
+    use winapi::shared::minwindef::DWORD;
+    use winapi::um::{
+        fileapi::{CreateFileW, OPEN_EXISTING},
+        handleapi::CloseHandle,
+        ioapiset::DeviceIoControl,
+        winbase::FILE_FLAG_BACKUP_SEMANTICS,
+        winioctl::{
+            IOCTL_STORAGE_QUERY_PROPERTY, STORAGE_DEVICE_DESCRIPTOR,
+            STORAGE_PROPERTY_QUERY, StorageDeviceProperty,
+        },
+        winnt::{FILE_SHARE_READ, FILE_SHARE_WRITE, GENERIC_READ, GENERIC_WRITE, HANDLE},
+    };
+
+    let wide: Vec<u16> = path.as_ref().encode_wide().chain(Some(0)).collect();
+    let handle: HANDLE = unsafe {
+        CreateFileW(
+            wide.as_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            std::ptr::null_mut(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS,
+            std::ptr::null_mut(),
+        )
+    };
+    if handle.is_null() {
+        return Ok(Bus::Unknown);
+    }
+
+    let mut query = STORAGE_PROPERTY_QUERY {
+        PropertyId: StorageDeviceProperty,
+        QueryType: 0,
+        AdditionalParameters: [0; 1],
+    };
+    // 512 B buffer is enough for the header we need.
+    let mut buf = [0u8; 512];
+    let mut bytes = 0u32;
+    let ok = unsafe {
+        DeviceIoControl(
+            handle,
+            IOCTL_STORAGE_QUERY_PROPERTY,
+            &mut query as *mut _ as *mut _,
+            mem::size_of::<STORAGE_PROPERTY_QUERY>() as DWORD,
+            buf.as_mut_ptr() as *mut _,
+            buf.len() as DWORD,
+            &mut bytes,
+            std::ptr::null_mut(),
+        )
+    };
+    unsafe { CloseHandle(handle) };
+
+    if ok == 0 {
+        return Ok(Bus::Unknown);
+    }
+
+    // The first byte of STORAGE_DEVICE_DESCRIPTOR after the header length
+    // is *BusType* (see winioctl.h).
+    let header_len = unsafe { (*(buf.as_ptr() as *const STORAGE_DEVICE_DESCRIPTOR)).HeaderSize };
+    let bus_byte = buf[header_len as usize];
+
+    let bus = match bus_byte {
+        0x07 => Bus::SataAHCI,     // SATA / ATA
+        0x10 => Bus::UsbBulkOnly,  // USB BOT
+        0x11 => Bus::UsbUasp,      // USB UASP (sometimes 0x10 as well)
+        0x17 => Bus::Nvme,
+        _    => Bus::Unknown,
+    };
+    Ok(bus)
+}
+
+#[cfg(target_os = "linux")]
+pub fn detect_bus_type<P: AsRef<std::path::Path>>(path: P) -> io::Result<Bus> {
+    use std::fs;
+    use std::os::unix::fs::MetadataExt;
+
+    let md = fs::metadata(&path)?;
+    let sys = format!("/sys/dev/block/{}:{}", md.rdev() >> 8, md.rdev() & 0xff);
+    let link = fs::read_link(&sys)?;
+    let p = link.to_string_lossy();
+
+    if p.contains("/usb") {
+        let modalias = fs::read_to_string(format!("{}/device/modalias", sys)).unwrap_or_default();
+        return if modalias.contains("uas") {
+            Ok(Bus::UsbUasp)
+        } else {
+            Ok(Bus::UsbBulkOnly)
+        };
+    }
+    if p.contains("/nvme") { return Ok(Bus::Nvme); }
+    if p.contains("/ata")  { return Ok(Bus::SataAHCI); }
+    if p.contains("/sas")  { return Ok(Bus::Sas);     }
+    Ok(Bus::Unknown)
+}
+
+#[cfg(target_os = "macos")]
+pub fn detect_bus_type<P: AsRef<std::path::Path>>(path: P) -> io::Result<Bus> {
+    // Re-use the text dump you already generate via `mac_usb_report`
+    if let Ok(tree) = crate::mac_usb_report::usb_storage_summary(
+        path.as_ref().to_str().unwrap_or_default()
+    ) {
+        if tree.contains("UAS")    { return Ok(Bus::UsbUasp);   }
+        if tree.contains("USB")    { return Ok(Bus::UsbBulkOnly);}
+    }
+    Ok(Bus::Unknown)
+}
+
+// Fallback stub so the crate still compiles everywhere.
+#[cfg(not(any(target_os = "windows", target_os = "linux", target_os = "macos")))]
+pub fn detect_bus_type<P, Q>(_: P) -> io::Result<Bus> { Ok(Bus::Unknown) }

--- a/src/hardware_info/mod.rs
+++ b/src/hardware_info/mod.rs
@@ -10,8 +10,11 @@ use sysinfo::Disks;
 
 use rusb::{Context, DeviceHandle, UsbContext};
 
+pub mod bus;
+pub use bus::{Bus, detect_bus_type};
+
 #[cfg(target_os = "macos")]
-#[path = "macos_iokit_stats.rs"]
+#[path = "../macos_iokit_stats.rs"]
 mod macos_iokit_stats;
 #[cfg(target_os = "macos")]
 pub use macos_iokit_stats::smart_metrics_from_bsd as smart_metrics;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use aligned_vec::AVec as AlignedVec;
 // Crates
 use chrono::Local;
 use clap::Parser;
-use crossbeam_channel::{bounded, Receiver, Sender};
+use crossbeam_channel::{bounded};
 use ctrlc;
 use disk_tester::{run_lean_test, LeanTest};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -2848,7 +2848,7 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
             log_simple(
                 &log_file_arc_opt,
                 None,
-                format!("\u27f3 auto-tune: threads={}  qd={}  batch={:.1} MiB",
+                format!("\u{27f3} auto-tune: threads={}  qd={}  batch={:.1} MiB",
                         threads, queue_depth, batch_bytes as f64 / 1_048_576.0)
             );
             let actual_batch_size_sectors =

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,7 @@ mod mac_usb_report;
 #[cfg(all(target_os = "macos", feature = "direct"))]
 mod macos_direct;
 mod serial;
+mod auto_tune;
 
 // Platform-specific imports
 #[cfg(all(target_os = "linux", feature = "direct"))]
@@ -238,20 +239,12 @@ enum Commands {
         resume_from_sector: u64,
         #[clap(long, value_parser = parse_size_with_suffix, default_value = "4K")]
         block_size: u64,
-        #[clap(
-            long,
-            default_value_t = 1,
-            help = "Number of parallel I/O worker threads."
-        )]
-        threads: usize,
-        #[clap(
-            long,
-            default_value_t = 32,
-            help = "Number of I/O batches to queue ahead (per-thread queue depth)."
-        )]
-        queue_depth: usize,
-        #[clap(long, value_parser = parse_size_with_suffix, default_value = "1M", help = "Total batch size for I/O operations (e.g., 4M, 256K).")]
-        batch_size: u64,
+        #[clap(long)]
+        threads: Option<usize>,
+        #[clap(long)]
+        queue_depth: Option<usize>,
+        #[clap(long, value_parser = parse_size_with_suffix)]
+        batch_size: Option<u64>,
         #[clap(long, value_enum, default_value = "binary")]
         data_type: DataTypeChoice,
         #[clap(long)]
@@ -2733,9 +2726,9 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
             test_size,
             resume_from_sector,
             block_size,
-            threads,
-            queue_depth,
-            batch_size,
+            threads: threads_opt,
+            queue_depth: queue_depth_opt,
+            batch_size: batch_size_opt,
             data_type,
             data_file,
             #[cfg(feature = "direct")]
@@ -2775,16 +2768,6 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
                     &log_file_arc_opt,
                     None,
                     format!("Effective block size: {} bytes", actual_block_size_u64),
-                );
-                log_simple(
-                    &log_file_arc_opt,
-                    None,
-                    format!("Worker Threads: {}", threads),
-                );
-                log_simple(
-                    &log_file_arc_opt,
-                    None,
-                    format!("Queue Depth: {}", queue_depth),
                 );
                 log_simple(
                     &log_file_arc_opt,
@@ -2854,17 +2837,22 @@ fn main_logic(log_file_arc_opt: Option<Arc<Mutex<File>>>) -> io::Result<()> {
                 );
             }
 
-            let actual_batch_size_sectors =
-                cmp::max(1, (batch_size / actual_block_size_u64) as usize);
+            // --- Auto-tune --------------------------------------------------------
+            let (threads, queue_depth, batch_bytes) = auto_tune::decide(
+                &file_path,
+                threads_opt,
+                queue_depth_opt,
+                batch_size_opt,
+                actual_block_size_u64,
+            );
             log_simple(
                 &log_file_arc_opt,
                 None,
-                format!(
-                    "Effective batch size: {} sectors ({} bytes per batch)",
-                    actual_batch_size_sectors,
-                    actual_batch_size_sectors as u64 * actual_block_size_u64
-                ),
+                format!("\u27f3 auto-tune: threads={}  qd={}  batch={:.1} MiB",
+                        threads, queue_depth, batch_bytes as f64 / 1_048_576.0)
             );
+            let actual_batch_size_sectors =
+                cmp::max(1, (batch_bytes / actual_block_size_u64) as usize);
 
             if passes == 0 || passes > 3 {
                 let msg = format!("passes must be between 1 and 3 (got {})", passes);

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -58,7 +58,7 @@ mod linux {
 
 /* ---------- WINDOWS ---------- */
 #[cfg(target_os = "windows")]
-mod windows {
+pub mod windows {
     use super::*;
     use std::{mem, os::windows::prelude::*, ptr};
     use winapi::ctypes::c_void;
@@ -172,19 +172,19 @@ mod windows {
     }
 
     #[repr(C)]
-    struct STORAGE_DEVICE_DESCRIPTOR {
-        version: u32,
-        size: u32,
-        device_type: u8,
-        device_type_modifier: u8,
-        removable_media: u8,
-        command_queueing: u8,
-        vendor_id_offset: u32,
-        product_id_offset: u32,
-        product_revision_offset: u32,
-        serial_number_offset: u32,
-        bus_type: u8,
-        raw_properties_length: u32,
+    pub struct STORAGE_DEVICE_DESCRIPTOR {
+        pub version: u32,
+    pub size: u32,
+    pub device_type: u8,
+    pub device_type_modifier: u8,
+    pub removable_media: u8,
+    pub command_queueing: u8,
+    pub vendor_id_offset: u32,
+    pub product_id_offset: u32,
+    pub product_revision_offset: u32,
+    pub serial_number_offset: u32,
+    pub bus_type: u8,
+    pub raw_properties_length: u32,
         // followed by raw data
     }
 


### PR DESCRIPTION
## Summary
- move `hardware_info.rs` into module directory
- add lightweight bus detection helper for Windows, Linux and macOS
- implement auto-tuning of worker threads, queue depth and batch size
- expose bus info via `hardware_info` module
- integrate auto-tuning into the `full-test` command and update CLI options

## Testing
- `cargo test` *(fails: libudev missing)*

------
https://chatgpt.com/codex/tasks/task_e_68714e24822c83319af89f90f692d798