### PR TITLE
Improve progress output clarity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "disk_tester"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "aligned-vec",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "disk_tester"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -2267,8 +2267,8 @@ fn full_reliability_test(
                     pb_arc.inc(msg.sector_count as u64);
                     
                     let batch_bytes = msg.sector_count as u64 * block_size_u64;
-                    let (off_start_val, off_start_unit) = format_bytes_int(msg.abs_start_sector * block_size_u64);
-                    let (off_end_val, off_end_unit) = format_bytes_int((msg.abs_start_sector + msg.sector_count as u64) * block_size_u64);
+                    let (off_start_val, off_start_unit) = format_bytes_float(msg.abs_start_sector * block_size_u64);
+                    let (off_end_val, off_end_unit) = format_bytes_float((msg.abs_start_sector + msg.sector_count as u64) * block_size_u64);
                     let (batch_val, batch_unit) = format_bytes_int(batch_bytes);
                     let (buf_val, buf_unit) = format_bytes_int(block_size_u64);
 
@@ -2283,11 +2283,11 @@ fn full_reliability_test(
                             &log_f_opt,
                             Some(&pb_arc),
                             format!(
-                                "{off_start_val} {off_start_unit} - \
-                                {off_end_val} {off_end_unit}: \
+                                "{off_start_val:.1} {off_start_unit} - \
+                                {off_end_val:.1} {off_end_unit}: \
                                 {batch_val} {batch_unit}/{buf_val} {buf_unit} (dual)  \
-                                binary {w0:.0} MiB/sec … {r0:.0} MiB/sec | \
-                                random {w1:.0} MiB/sec … {r1:.0} MiB/sec"
+                                binary {w0:.1} MiB/s … {r0:.1} MiB/s | \
+                                random {w1:.1} MiB/s … {r1:.1} MiB/s"
                             )
                         );
                     } else {
@@ -2304,7 +2304,7 @@ fn full_reliability_test(
                             &log_f_opt,
                             Some(&pb_arc),
                             format!(
-                                "{off_start_val} {off_start_unit} - {off_end_val} {off_end_unit}: {batch_val} {batch_unit}/{buf_val} {buf_unit} ({})  {:.0} MiB/sec W, {:.0} MiB/s R",
+                                "{off_start_val:.1} {off_start_unit} - {off_end_val:.1} {off_end_unit}: {batch_val} {batch_unit}/{buf_val} {buf_unit} ({})  {w0:.1} MiB/s W, {r0:.1} MiB/s R",
                                 base_label,
                                 w0,
                                 r0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2283,13 +2283,13 @@ fn full_reliability_test(
                             &log_f_opt,
                             Some(&pb_arc),
                             format!(
-                                "{off_start_val:.1} {off_start_unit} - \
-                                {off_end_val:.1} {off_end_unit}: \
+                                "{off_start_val:.1} {off_start_unit} - {off_end_val:.1} {off_end_unit}: \
                                 {batch_val} {batch_unit}/{buf_val} {buf_unit} (dual)  \
-                                binary {w0:.1} MiB/s … {r0:.1} MiB/s | \
-                                random {w1:.1} MiB/s … {r1:.1} MiB/s"
-                            )
+                                binary  write {w0:.1} MiB/s, read {r0:.1} MiB/s | \
+                                random  write {w1:.1} MiB/s, read {r1:.1} MiB/s"
+                            ),
                         );
+
                     } else {
                         let w0 = mib_s(batch_bytes, msg.write_secs_first);
                         let r0 = mib_s(batch_bytes, msg.read_secs_first);
@@ -2304,7 +2304,7 @@ fn full_reliability_test(
                             &log_f_opt,
                             Some(&pb_arc),
                             format!(
-                                "{off_start_val:.1} {off_start_unit} - {off_end_val:.1} {off_end_unit}: {batch_val} {batch_unit}/{buf_val} {buf_unit} ({})  {w0:.1} MiB/s W, {r0:.1} MiB/s R",
+                                "{off_start_val:.1} {off_start_unit} - {off_end_val:.1} {off_end_unit}: {batch_val} {batch_unit}/{buf_val} {buf_unit} ({})  {:.1} MiB/s W, {:.1} MiB/s R",
                                 base_label,
                                 w0,
                                 r0,


### PR DESCRIPTION
## Summary
- better precision for progress bar address display
- use one decimal place for MiB/s metrics

## Testing
- `cargo test` *(fails: libudev not found)*

------
https://chatgpt.com/codex/tasks/task_e_687156c62174833198172e64c23e23f7