### PR TITLE
feat: Add CI workflow for cross-platform testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        feature: ["", "direct"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose --no-default-features ${{ matrix.feature != '' && format('--features {0}', matrix.feature) || '' }}
+    - name: Run tests
+      run: cargo test --verbose --no-default-features ${{ matrix.feature != '' && format('--features {0}', matrix.feature) || '' }}

--- a/src/macos_direct.rs
+++ b/src/macos_direct.rs
@@ -21,3 +21,23 @@ pub fn enable_nocache(file: &std::fs::File) -> io::Result<()> {
     }
     Ok(())
 }
+
+#[cfg(not(all(target_os = "macos", feature = "direct")))]
+pub fn enable_nocache(_file: &std::fs::File) -> std::io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::File;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    #[cfg(all(target_os = "macos", feature = "direct"))]
+    fn test_enable_nocache() {
+        let tmp_file = NamedTempFile::new().unwrap();
+        let file = File::open(tmp_file.path()).unwrap();
+        assert!(enable_nocache(&file).is_ok());
+    }
+}


### PR DESCRIPTION
This change introduces a GitHub Actions workflow to build and test the project on Linux, Windows, and macOS, both with and without the `direct` feature.

fix: Resolve macOS compilation issues with direct I/O

This change resolves compilation issues on macOS when the `direct` feature is enabled by providing a stub function for `enable_nocache` on other platforms and fixing conditional compilation flags in `main.rs`.

test: Add unit test for enable_nocache on macOS

This change adds a unit test for the `enable_nocache` function on macOS.